### PR TITLE
Deprecations and typo fixes

### DIFF
--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -17,6 +17,8 @@ class StreamWrapper
 
     private $stream;
 
+    public $context;
+
     public static function fdFromStream($stream): int
     {
         $meta = stream_get_meta_data($stream);

--- a/src/inotify.php
+++ b/src/inotify.php
@@ -173,13 +173,13 @@ function inotify_read($stream): array
     $bufSize = max(FFI::sizeof($inotifyEventType) + 255, 128);
 
     while (true) {
-        $buf = $ffi->new(FFI::arrayType(FFI::type('char'), [$bufSize]));
+        $buf = $ffi->new(FFI::arrayType($ffi->type('char'), [$bufSize]));
         $readden = $ffi->read($fd, $buf, $bufSize);
 
         if ($readden === -1) {
             // buf too small to read an event
             if ($ffi->errno === EINVAL) {
-                $bufSize = (int) ceil($buffize * 1.6);
+                $bufSize = (int) ceil($bufSize * 1.6);
                 continue;
             }
             // fd is unblocking, and no event is available


### PR DESCRIPTION
Fixed two deprecations and a typo in the $bufSize variable name.

```
Deprecated: Creation of dynamic property Alb\Inotify\StreamWrapper::$context is deprecated
Deprecated: Calling FFI::type() statically is deprecated
```